### PR TITLE
Add dependency on unstable-lib.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang setup/infotab
 
 (define collection 'multi)
-(define deps '("base" "scribble-lib"))
+(define deps '("base" "scribble-lib" "unstable-lib"))
 (define build-deps '("racket-doc" "unstable-doc"))
 
 ; vim:set ts=2 sw=2 et:


### PR DESCRIPTION
`unstable/error` is moving there as of Racket 6.2.900.17.
This dependency is not necessary for 6.2.1, but will be starting with the next release.
